### PR TITLE
support rollup_personal endpoint

### DIFF
--- a/l2geth/rpc/service.go
+++ b/l2geth/rpc/service.go
@@ -98,6 +98,18 @@ func (r *serviceRegistry) callback(method string) *callback {
 	if len(elem) != 2 {
 		return nil
 	}
+
+	// support `rollup_personal`
+	parentElem := elem[1]
+	count := strings.Count(parentElem, serviceMethodSeparator)
+	if count == 1 {
+		childElem := strings.SplitN(parentElem, serviceMethodSeparator, 2)
+		elem[0] = elem[0] + serviceMethodSeparator + childElem[0]
+		elem[1] = childElem[1]
+	} else if 1 < count {
+		return nil
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.services[elem[0]].callbacks[elem[1]]


### PR DESCRIPTION
The L2 GSA suggestion endpoint currently always returns a gas fee of `0`, which is inconvenient for Verse where users are charged for gas. The L2 gas price can be set via the `rollup_personal` namespace API, but this has not been functioning due to a bug.

In this PR, I have addressed the bug, enabling the modification of the L2 suggested gas fee.